### PR TITLE
[fix(location)]: fix the SLX T0 creating vms problem

### DIFF
--- a/ansible/host_vars/STR-ACS-SERV-03.yml
+++ b/ansible/host_vars/STR-ACS-SERV-03.yml
@@ -1,0 +1,4 @@
+mgmt_bridge: br2
+mgmt_prefixlen: 23
+mgmt_gw: 10.251.0.1
+external_port: enp175s0f0

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -14,7 +14,7 @@ testcases:
 
     bgp_fact:
       filename: bgp_fact.yml
-      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-slx, t0-e1031, t1, t1-lag, t1-64-lag]
+      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-slx, t0-e1031, t1, t1-lag, t1-64-lag, t1-slx]
 
 
     bgp_multipath_relax:

--- a/ansible/veos
+++ b/ansible/veos
@@ -4,9 +4,13 @@ STR-ACS-SERV-01 ansible_host=10.250.0.1
 [vm_host_2]
 STR-ACS-SERV-02 ansible_host=10.251.0.1
 
+[vm_host_3]
+STR-ACS-SERV-03 ansible_host=10.251.0.1
+
 [vm_host:children]
 vm_host_1
 vm_host_2
+vm_host_3
 
 [vms_1]
 VM0100 ansible_host=10.250.0.2
@@ -54,6 +58,7 @@ VM0300 ansible_host=10.251.0.2
 VM0301 ansible_host=10.251.0.3
 VM0302 ansible_host=10.251.0.4
 VM0303 ansible_host=10.251.0.5
+
 
 [vms_4]
 VM0400 ansible_host=10.251.0.10
@@ -112,11 +117,11 @@ vms_3
 host_var_file=host_vars/STR-ACS-SERV-02.yml
 
 [server_3:children]
-vm_host_2
+vm_host_3
 vms_4
 
 [server_3:vars]
-host_var_file=host_vars/STR-ACS-SERV-02.yml
+host_var_file=host_vars/STR-ACS-SERV-03.yml
 
 [servers:children]
 server_1
@@ -124,4 +129,4 @@ server_2
 server_3
 
 [servers:vars]
-topologies=['t1', 't1-lag', 't1-64-lag', 't0', 't0-16', 't0-56', 't0-52', 't0-slx', 't0-e1031', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116']
+topologies=['t1', 't1-lag', 't1-64-lag', 't1-slx', 't0', 't0-16', 't0-56', 't0-52', 't0-slx', 't0-e1031', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116']


### PR DESCRIPTION
[body]: When used command './testbed-cli.sh start-vms server_2
password.txt' to create 4 vms for SLX T0, would create SLX T1's
vms set.
  The reason is the 'veos' file maked some confused configures, the
vm_host_2 was used by server_2/server_3. And leading the ansible-
testbed got the wrong vms information. So adding the new vm_host_3
parameter for the server_3(SLX T1 used) to fix the bug, and create
new file STR-ACS-SERV-03.yml for SLX T1's virtual bridge.For sure the
SLX T1 working right, added the t1-slx topo-type into the testcases.yml
(just the bgp_fact case).

added and modified files:
    new file:   ansible/host_vars/STR-ACS-SERV-03.yml
    modified:   ansible/roles/test/vars/testcases.yml
    modified:   ansible/veos

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
